### PR TITLE
Adding option to match without replacement.

### DIFF
--- a/pymatch/Matcher.py
+++ b/pymatch/Matcher.py
@@ -141,7 +141,7 @@ class Matcher:
             scores += m.predict(self.X[m.params.index])
         self.data['scores'] = scores/self.nmodels
 
-    def match(self, threshold=0.001, nmatches=1, method='min', max_rand=10, matchtype='replacement'):
+    def match(self, threshold=0.001, nmatches=1, method='min', max_rand=10, with_replacement=True):
         """
         Finds suitable match(es) for each record in the minority
         dataset, if one exists. Records are exlcuded from the final
@@ -165,11 +165,11 @@ class Matcher:
             "min" - choose the profile with the closest score
         max_rand : int
             max number of profiles to consider when using random tie-breaks
-        matchtype : str
-            "replacement" - matching is performed with replacement, in the 
+        with_replacement : bool
+            True - matching is performed with replacement, in the 
             majority group. The same entry from the majority group can be 
             matched to multiple entries from the minority group
-            "no_replacement" - matching is performed without replacement, in 
+            False - matching is performed without replacement, in 
             the majority group. All matches consist of unique entries. 
             Matching order is randomized.
 


### PR DESCRIPTION
Hi Ben,

Thanks for making this nice tool! If you like, i've implemented a new feature that is common in eg. R packages for the same purpose which is to have the option to match without replacement. The downsides to this can be slightly worse matching overall as well as possible order effects - however for some types of analyses you really want to have unique subjects in each group. Now the user has the choice to make that decision! :)

I've also implemented (line 189) a randomization for the order in which the matching proceeds. This is so that you can check for said ordering effects, and e.g. run it a couple of times until the matching is at a desirable level.

Please let me know if i can make anything more clear.
it's my first GH pull request so i hope i am following the right protocol.

All the best!

Tristan